### PR TITLE
[gdrive] code_challenge_method に SHA-256 方式を使う

### DIFF
--- a/src/miraktest-gdrive/GDriveRenderer.tsx
+++ b/src/miraktest-gdrive/GDriveRenderer.tsx
@@ -7,6 +7,7 @@ import { ContentPlayerPlayingContent, InitPlugin } from "../@types/plugin"
 import tailwind from "../tailwind.scss"
 import { FileSelector } from "./components/FileSelector"
 import {
+  GDRIVE_CALC_S256,
   GDRIVE_GET_PORT,
   GDRIVE_META,
   GDRIVE_PREFIX,
@@ -15,7 +16,7 @@ import {
   GDRIVE_WINDOW_ID,
 } from "./constants"
 import { GDRIVE_CLIENT_ID, GDRIVE_CLIENT_SECRET } from "./cred"
-import { generateRandomString, generateS256CodeChallenge } from "./utils"
+import { generateRandomString } from "./utils"
 
 const refine = $.withDefault(
   $.object({
@@ -238,7 +239,7 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                       "text-gray-800",
                       "font-semibold"
                     )}
-                    onClick={() => {
+                    onClick={async () => {
                       const url = new URL(
                         "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&scope=$SCOPE"
                       )
@@ -253,8 +254,14 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                         "https://www.googleapis.com/auth/drive.readonly"
                       )
                       const verifier = generateRandomString(43)
-                      const challenge = generateS256CodeChallenge(verifier)
-                      url.searchParams.set("code_challenge", challenge)
+                      const challenge = await rpc.invoke(
+                        GDRIVE_CALC_S256,
+                        verifier
+                      )
+                      url.searchParams.set(
+                        "code_challenge",
+                        challenge as string
+                      )
                       url.searchParams.set("code_challenge_method", "S256")
                       rpc.invoke(GDRIVE_SET_CRED, {
                         clientId: useClientId,
@@ -478,7 +485,7 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                           "bg-gray-200",
                           "font-semibold"
                         )}
-                        onClick={() => {
+                        onClick={async () => {
                           const url = new URL(
                             "https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&scope=$SCOPE"
                           )
@@ -490,8 +497,14 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                             "https://www.googleapis.com/auth/drive.readonly"
                           )
                           const verifier = generateRandomString(43)
-                          const challenge = generateS256CodeChallenge(verifier)
-                          url.searchParams.set("code_challenge", challenge)
+                          const challenge = await rpc.invoke(
+                            GDRIVE_CALC_S256,
+                            verifier
+                          )
+                          url.searchParams.set(
+                            "code_challenge",
+                            challenge as string
+                          )
                           url.searchParams.set("code_challenge_method", "S256")
                           rpc.invoke(GDRIVE_SET_CRED, {
                             clientId: useClientId,

--- a/src/miraktest-gdrive/GDriveRenderer.tsx
+++ b/src/miraktest-gdrive/GDriveRenderer.tsx
@@ -252,7 +252,7 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                         "scope",
                         "https://www.googleapis.com/auth/drive.readonly"
                       )
-                      const challenge = generateRandomString(10)
+                      const challenge = generateRandomString(43)
                       url.searchParams.set("code_challenge", challenge)
                       url.searchParams.set("code_challenge_method", "plain")
                       rpc.invoke(GDRIVE_SET_CRED, {
@@ -488,7 +488,7 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                             "scope",
                             "https://www.googleapis.com/auth/drive.readonly"
                           )
-                          const challenge = generateRandomString(10)
+                          const challenge = generateRandomString(43)
                           url.searchParams.set("code_challenge", challenge)
                           url.searchParams.set("code_challenge_method", "plain")
                           rpc.invoke(GDRIVE_SET_CRED, {

--- a/src/miraktest-gdrive/GDriveRenderer.tsx
+++ b/src/miraktest-gdrive/GDriveRenderer.tsx
@@ -15,7 +15,7 @@ import {
   GDRIVE_WINDOW_ID,
 } from "./constants"
 import { GDRIVE_CLIENT_ID, GDRIVE_CLIENT_SECRET } from "./cred"
-import { generateRandomString } from "./utils"
+import { generateRandomString, generateS256CodeChallenge } from './utils'
 
 const refine = $.withDefault(
   $.object({
@@ -252,13 +252,14 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                         "scope",
                         "https://www.googleapis.com/auth/drive.readonly"
                       )
-                      const challenge = generateRandomString(43)
+                      const verifier = generateRandomString(43)
+                      const challenge = generateS256CodeChallenge(verifier)
                       url.searchParams.set("code_challenge", challenge)
-                      url.searchParams.set("code_challenge_method", "plain")
+                      url.searchParams.set("code_challenge_method", "S256")
                       rpc.invoke(GDRIVE_SET_CRED, {
                         clientId: useClientId,
                         clientSecret: useClientSecret,
-                        challenge,
+                        verifier,
                         redirectUri,
                       })
                       window.open(url.href, "_blank")
@@ -488,13 +489,14 @@ export const GDriveRenderer: InitPlugin["renderer"] = ({
                             "scope",
                             "https://www.googleapis.com/auth/drive.readonly"
                           )
-                          const challenge = generateRandomString(43)
+                          const verifier = generateRandomString(43)
+                          const challenge = generateS256CodeChallenge(verifier)
                           url.searchParams.set("code_challenge", challenge)
-                          url.searchParams.set("code_challenge_method", "plain")
+                          url.searchParams.set("code_challenge_method", "S256")
                           rpc.invoke(GDRIVE_SET_CRED, {
                             clientId: useClientId,
                             clientSecret: useClientSecret,
-                            challenge,
+                            verifier,
                             redirectUri,
                           })
                           window.open(url.href, "_blank")

--- a/src/miraktest-gdrive/GDriveRenderer.tsx
+++ b/src/miraktest-gdrive/GDriveRenderer.tsx
@@ -15,7 +15,7 @@ import {
   GDRIVE_WINDOW_ID,
 } from "./constants"
 import { GDRIVE_CLIENT_ID, GDRIVE_CLIENT_SECRET } from "./cred"
-import { generateRandomString, generateS256CodeChallenge } from './utils'
+import { generateRandomString, generateS256CodeChallenge } from "./utils"
 
 const refine = $.withDefault(
   $.object({

--- a/src/miraktest-gdrive/Main.ts
+++ b/src/miraktest-gdrive/Main.ts
@@ -16,7 +16,7 @@ import {
 type OAuth2Cred = {
   clientId: string
   clientSecret: string
-  challenge: string
+  verifier: string
   redirectUri: string
 }
 
@@ -73,7 +73,7 @@ export const Main: InitPlugin["main"] = async ({ packages, functions }) => {
         }
         const params = new URLSearchParams()
         params.set("code", code)
-        params.set("code_verifier", oauth2Cred.challenge)
+        params.set("code_verifier", oauth2Cred.verifier)
         params.set("client_id", oauth2Cred.clientId)
         params.set("client_secret", oauth2Cred.clientSecret)
         params.set("redirect_uri", oauth2Cred.redirectUri)

--- a/src/miraktest-gdrive/constants.ts
+++ b/src/miraktest-gdrive/constants.ts
@@ -11,5 +11,6 @@ export const GDRIVE_META = {
 }
 export const GDRIVE_WINDOW_ID = `${GDRIVE_ID}.gdrive`
 export const GDRIVE_GET_PORT = `${GDRIVE_PREFIX}.getPort`
+export const GDRIVE_CALC_S256 = `${GDRIVE_PREFIX}.calcS256`
 export const GDRIVE_SET_CRED = `${GDRIVE_PREFIX}.setCred`
 export const GDRIVE_SET_ACCESS_TOKEN = `${GDRIVE_PREFIX}.setAccessToken`

--- a/src/miraktest-gdrive/utils.ts
+++ b/src/miraktest-gdrive/utils.ts
@@ -1,5 +1,3 @@
-import { createHash } from "crypto"
-
 export const generateRandomString = (length = 6) => {
   let result = ""
   const characters =
@@ -9,15 +7,4 @@ export const generateRandomString = (length = 6) => {
     result += characters.charAt(Math.floor(Math.random() * charactersLength))
   }
   return result
-}
-
-export const generateS256CodeChallenge = (verifier: string) => {
-  return (
-    createHash("sha256")
-      .update(verifier, "utf8")
-      // base64url 形式 (https://datatracker.ietf.org/doc/html/rfc4648#section-5) でダイジェストを生成
-      .digest("base64url")
-      // Base64 のパディングを削除
-      .replace(/=+$/, "")
-  )
 }

--- a/src/miraktest-gdrive/utils.ts
+++ b/src/miraktest-gdrive/utils.ts
@@ -12,10 +12,12 @@ export const generateRandomString = (length = 6) => {
 }
 
 export const generateS256CodeChallenge = (verifier: string) => {
-  return createHash("sha256")
-    .update(verifier, "utf8")
-    // base64url 形式 (https://datatracker.ietf.org/doc/html/rfc4648#section-5) でダイジェストを生成
-    .digest("base64url")
-    // Base64 のパディングを削除
-    .replace(/=+$/, "")
+  return (
+    createHash("sha256")
+      .update(verifier, "utf8")
+      // base64url 形式 (https://datatracker.ietf.org/doc/html/rfc4648#section-5) でダイジェストを生成
+      .digest("base64url")
+      // Base64 のパディングを削除
+      .replace(/=+$/, "")
+  )
 }

--- a/src/miraktest-gdrive/utils.ts
+++ b/src/miraktest-gdrive/utils.ts
@@ -3,7 +3,7 @@ import { createHash } from "crypto"
 export const generateRandomString = (length = 6) => {
   let result = ""
   const characters =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
   const charactersLength = characters.length
   for (let i = 0; i < length; i++) {
     result += characters.charAt(Math.floor(Math.random() * charactersLength))

--- a/src/miraktest-gdrive/utils.ts
+++ b/src/miraktest-gdrive/utils.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto"
+
 export const generateRandomString = (length = 6) => {
   let result = ""
   const characters =
@@ -7,4 +9,13 @@ export const generateRandomString = (length = 6) => {
     result += characters.charAt(Math.floor(Math.random() * charactersLength))
   }
   return result
+}
+
+export const generateS256CodeChallenge = (verifier: string) => {
+  return createHash("sha256")
+    .update(verifier, "utf8")
+    // base64url 形式 (https://datatracker.ietf.org/doc/html/rfc4648#section-5) でダイジェストを生成
+    .digest("base64url")
+    // Base64 のパディングを削除
+    .replace(/=+$/, "")
 }


### PR DESCRIPTION
- Google Drive との OAuth2 で使用している PKCE で code_challenge_method を `plain` → `S256` に変更しました
- [RFC](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1) 的には code_verifier は 43 ~ 128桁だったので桁数を増やしました
  - ついでに使える文字種を規定通りにしました