### PR TITLE
ローカルファイルのパスをどの環境でも動くように組み立てる・ファイル名に # が入っていても壊れないようにする

### DIFF
--- a/src/miraktest-local/components/FileSelector.tsx
+++ b/src/miraktest-local/components/FileSelector.tsx
@@ -126,10 +126,16 @@ export const FileSelector: React.VFC<{
                   if (!path) {
                     return
                   }
-                  setFilePath(
-                    // Windows なら file:///C:\path\to\file.m2ts、Linux / Mac なら file:///path/to/file.m2ts になるように加工する
-                    "file:///" + path.at(0) === "/" ? path.slice(1) : path
-                  )
+                  // Windows なら file:///C:\path\to\file.m2ts、Linux / Mac なら file:///path/to/file.m2ts になるように加工する。パスの要素それぞれに対してパーセントエンコードをする
+                  const url =
+                    "file:///" +
+                    path
+                      .replaceAll(/\\/g, "/")
+                      .split("/")
+                      .filter((p) => p !== "")
+                      .map((p) => encodeURIComponent(p))
+                      .join("/")
+                  setFilePath(url)
                 }}
               >
                 <File className="pointer-events-none" size="1.75rem" />

--- a/src/miraktest-local/components/FileSelector.tsx
+++ b/src/miraktest-local/components/FileSelector.tsx
@@ -122,11 +122,14 @@ export const FileSelector: React.VFC<{
                   if (dialog.canceled) {
                     return
                   }
-                  const path = dialog.filePaths.slice(0).shift()
+                  const path = dialog.filePaths.at(0)
                   if (!path) {
                     return
                   }
-                  setFilePath("file://" + path)
+                  setFilePath(
+                    // Windows なら file:///C:\path\to\file.m2ts、Linux / Mac なら file:///path/to/file.m2ts になるように加工する
+                    "file:///" + path.at(0) === "/" ? path.slice(1) : path
+                  )
                 }}
               >
                 <File className="pointer-events-none" size="1.75rem" />


### PR DESCRIPTION
Windows だとローカルファイルを開けなかったので修正した
他にも `#` が入っていると URL 的にハッシュとして扱われてパスが壊れるので、パス要素ごとに URL エンコードするようにした

Windows で動くことを確認済み

FYI: https://www.koikikukan.com/archives/2012/05/14-000300.php